### PR TITLE
最小化したウィンドウの情報を複数持てるようにする

### DIFF
--- a/VimHotkeyWindowManager/WindowManager.cpp
+++ b/VimHotkeyWindowManager/WindowManager.cpp
@@ -12,6 +12,13 @@ bool OnDestroy(HWND hWnd, NOTIFYICONDATA nid, HMENU hMenu)
 	UnregisterHotKey(hWnd, HOTKEY_MINIMIZE);
 	UnregisterHotKey(hWnd, HOTKEY_RESTORE);
 
+	MinimizedWindow* current_minimized_window = head_minimized_window;
+	while (current_minimized_window) {
+		MinimizedWindow* next_minimized_window = current_minimized_window->next_window;
+		delete current_minimized_window;
+		current_minimized_window = next_minimized_window;
+	}
+
 	// Destroy monitor list
 	Monitor* current = primary_monitor;
 	while (current) {
@@ -27,6 +34,7 @@ bool OnDestroy(HWND hWnd, NOTIFYICONDATA nid, HMENU hMenu)
 		delete current_window;
 		current_window = next_window;
 	}
+
 
 	// Destroy window ( tasktray icon )
 	DestroyWindow(hWnd);

--- a/VimHotkeyWindowManager/window.cpp
+++ b/VimHotkeyWindowManager/window.cpp
@@ -2,6 +2,7 @@
 
 // Global Lists of Monitors and Windows
 Window *head_window = nullptr;
+MinimizedWindow *head_minimized_window = nullptr;
 
 
 // Constructor of the Window struct
@@ -26,6 +27,28 @@ void Window::SetPrevWindow(Window* prev) {
 }
 
 
+// Constructor of the MinimizedWindow struct
+// Initialize the minimized window with the Window
+MinimizedWindow::MinimizedWindow(Window* window)
+	: window(window) {}
+	
+
+// Set the next minimized window of the current minimized window
+void MinimizedWindow::SetNextWindow(MinimizedWindow* next) {
+	next_window = next;
+	if (next) {
+		next->prev_window = this;
+	}
+}
+
+// Set the previous minimized window of the current minimized window
+void MinimizedWindow::SetPrevWindow(MinimizedWindow* prev) {
+	prev_window = prev;
+	if (prev) {
+		prev->next_window = this;
+	}
+}
+
 // Helper functions 
 
 // Add the window to the global list by the HWND and the Monitor
@@ -38,6 +61,27 @@ bool AddWindowToList(HWND hWnd, Monitor* monitor) {
 	}
 
 	return true;
+}
+
+// Push the minimized window to the global list
+bool PushMinimizedWindowToList(Window *window) {
+	MinimizedWindow *current = head_minimized_window;
+	head_minimized_window = new MinimizedWindow(window);
+	if (current != nullptr) {
+		head_minimized_window->SetNextWindow(current);
+	}
+
+	return true;
+}
+
+// Pop the minimized window from the global list
+MinimizedWindow *PopMinimizedWindow() {
+	MinimizedWindow *current = head_minimized_window;
+	if (current != nullptr) {
+		head_minimized_window = current->next_window;
+		return current;
+	}
+	return nullptr;
 }
 
 // Find the window in the global list by the HWND
@@ -53,3 +97,4 @@ Window* FindWindowByHwnd(HWND hwnd) {
     }
     return nullptr; 
 }
+

--- a/VimHotkeyWindowManager/window.cpp
+++ b/VimHotkeyWindowManager/window.cpp
@@ -41,14 +41,6 @@ void MinimizedWindow::SetNextWindow(MinimizedWindow* next) {
 	}
 }
 
-// Set the previous minimized window of the current minimized window
-void MinimizedWindow::SetPrevWindow(MinimizedWindow* prev) {
-	prev_window = prev;
-	if (prev) {
-		prev->next_window = this;
-	}
-}
-
 // Helper functions 
 
 // Add the window to the global list by the HWND and the Monitor

--- a/VimHotkeyWindowManager/window.h
+++ b/VimHotkeyWindowManager/window.h
@@ -45,7 +45,6 @@ struct MinimizedWindow {
 
     MinimizedWindow(Window* window);
     void SetNextWindow(MinimizedWindow* next);
-    void SetPrevWindow(MinimizedWindow* prev);
 };
 
 // Used in global scope

--- a/VimHotkeyWindowManager/window.h
+++ b/VimHotkeyWindowManager/window.h
@@ -38,9 +38,22 @@ struct Window {
     void SetPrevWindow(Window* prev);
 };
 
+struct MinimizedWindow {
+    Window* window;
+    MinimizedWindow *next_window = nullptr;
+    MinimizedWindow *prev_window = nullptr;
+
+    MinimizedWindow(Window* window);
+    void SetNextWindow(MinimizedWindow* next);
+    void SetPrevWindow(MinimizedWindow* prev);
+};
+
 // Used in global scope
 extern Window *head_window;
+extern MinimizedWindow *head_minimized_window;
 
 bool AddWindowToList(HWND hWnd, Monitor* monitor);
+bool PushMinimizedWindowToList(Window* window);
+MinimizedWindow* PopMinimizedWindow();
 Window* FindWindowByHwnd(HWND hwnd);
 


### PR DESCRIPTION
MinimizedWindow構造体を定義
連結リストにすることで、複数のWindow構造体を持てるようにした
resolve #18 